### PR TITLE
Update the solution to support Customer Managed Policy and PermissionSet session duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,13 @@ These 2 event rules will trigger the lambda function when AWS detects manual wri
 
 ## Examples of mapping files
 1. Example of permission-set file (random account ids):
+
+    Note: This solution(version 1.1.0 or newer) supports advanced customer managed policy feature in the permission-set definition file:
+    1. Only use "CustomerPolicies" object in the definition file if you need to apply customer managed policy to your permission-set.
+    2. When you create a permission set with a customer managed policy, you MUST create an IAM policy with the same name and path in each AWS account where IAM Identity Center assigns your permission set. If you are specifying a custom path, make sure to specify the same path in each AWS account.
+
 ```
+
 {
     "Name": "1-example-admin",
     "Description": "1-example-admin",
@@ -179,6 +185,16 @@ These 2 event rules will trigger the lambda function when AWS detects manual wri
             "Arn": "arn:aws:iam::aws:policy/AdministratorAccess"
         }
     ],
+    "CustomerPolicies": [
+        {
+            "Name": "customer-managed-policy-1",
+            "Path": "/IAM-path-example/"
+        },
+        {
+            "Name": "customer-managed-policy-2",
+            "Path": "/"
+        }
+    ], 
     "InlinePolicies": []
 }
 

--- a/README.md
+++ b/README.md
@@ -165,9 +165,11 @@ These 2 event rules will trigger the lambda function when AWS detects manual wri
 1. Example of permission set file (random account ids):
 
     Note: This solution(version 1.1.0 or newer) supports 1)customer managed policy and 2) session duration feature in the permission set definition file:
-    1. Only use "CustomerPolicies" object in the definition file if you need to apply customer managed policy to your permission set. When you create a permission set with a customer managed policy, you MUST create an IAM policy with the same name and path in each AWS account where IAM Identity Center assigns your permission set. If you are specifying a custom path, make sure to specify the same path in each AWS account.
-    2. Only use "CustomerPolicies" object in the definition file if you need to apply custom session duration for certain permission set as the following example. You can set your default permission set "SessionDuration" in the identity-center-automation.template or using identity-center-stacks-parameters.json file. 
-        - To change the "Session_Duration" on existing permission set: 1) Recreate the permission set using CICD pipeline 2) Update the both  "Session_Duration" and "Description" section in the definition file. 
+    1. Only use the "CustomerPolicies" object in the definition file if you need to apply customer managed policy to your permission set. When you create a permission the set with a customer managed policy, you MUST create an IAM policy with the same name and path in each AWS account where IAM Identity Center assigns your permission set. If you are specifying a custom path, make sure to specify the same path in each AWS account.
+    2. You can apply custom permission set *session duration* for selected permission by adding "Session_Duration" in the mapping file (e.g 1-example-admin). You can set your own default permission set "SessionDuration" in the identity-center-automation.template or using identity-center-stacks-parameters.json file, current default value is 1 hour.
+        - To change the "Session_Duration" on existing permission set: 
+            - Option 1) Recreate the permission set using CICD pipeline 
+            - Option 2) Update the both  "Session_Duration" and "Description" section in the definition file and re-run the pipeline.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -162,17 +162,19 @@ These 2 event rules will trigger the lambda function when AWS detects manual wri
 ---
 
 ## Examples of mapping files
-1. Example of permission-set file (random account ids):
+1. Example of permission set file (random account ids):
 
-    Note: This solution(version 1.1.0 or newer) supports advanced customer managed policy feature in the permission-set definition file:
-    1. Only use "CustomerPolicies" object in the definition file if you need to apply customer managed policy to your permission-set.
-    2. When you create a permission set with a customer managed policy, you MUST create an IAM policy with the same name and path in each AWS account where IAM Identity Center assigns your permission set. If you are specifying a custom path, make sure to specify the same path in each AWS account.
+    Note: This solution(version 1.1.0 or newer) supports 1)customer managed policy and 2) session duration feature in the permission set definition file:
+    1. Only use "CustomerPolicies" object in the definition file if you need to apply customer managed policy to your permission set. When you create a permission set with a customer managed policy, you MUST create an IAM policy with the same name and path in each AWS account where IAM Identity Center assigns your permission set. If you are specifying a custom path, make sure to specify the same path in each AWS account.
+    2. Only use "CustomerPolicies" object in the definition file if you need to apply custom session duration for certain permission set as the following example. You can set your default permission set "SessionDuration" in the identity-center-automation.template or using identity-center-stacks-parameters.json file. 
+        - To change the "Session_Duration" on existing permission set: 1) Recreate the permission set using CICD pipeline 2) Update the both  "Session_Duration" and "Description" section in the definition file. 
 
 ```
 
 {
     "Name": "1-example-admin",
     "Description": "1-example-admin",
+    "Session_Duration": "PT12H",
     "Tags": [
         {
             "Key": "identity-center-solution",

--- a/identity-center-automation.template
+++ b/identity-center-automation.template
@@ -37,6 +37,11 @@ Parameters:
   SNSEmailEndpointSubscription:
     Description: The SNS subscription which used to receive SNS email notification.
     Type: String
+  SessionDuration:
+    Description: The length of time that the application user sessions are valid for in the ISO-8601 standard. Default is 3 hours.
+    Type: String
+    AllowedPattern: ^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$
+    Default: PT3H
   ICAutomationAdminArn:
     Type: String
     Description: >-
@@ -60,7 +65,8 @@ Resources:
       Environment:
         Variables:
           IC_InstanceArn: !Ref ICInstanceARN
-          IC_S3_BucketName: !Ref ICMappingBucketName        
+          IC_S3_BucketName: !Ref ICMappingBucketName
+          Session_Duration: !Ref SessionDuration
           SNS_Topic_Name:  'ic-automation-topic'
           Lambda_Region: !Ref "AWS::Region"
       MemorySize: 256

--- a/identity-center-automation.template
+++ b/identity-center-automation.template
@@ -38,10 +38,10 @@ Parameters:
     Description: The SNS subscription which used to receive SNS email notification.
     Type: String
   SessionDuration:
-    Description: The length of time that the application user sessions are valid for in the ISO-8601 standard. Default is 3 hours.
+    Description: The length of time that the application user sessions are valid for in the ISO-8601 standard. Default is 1 hours.
     Type: String
     AllowedPattern: ^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$
-    Default: PT3H
+    Default: PT1H
   ICAutomationAdminArn:
     Type: String
     Description: >-

--- a/identity-center-mapping-info/CHANGELOG.md
+++ b/identity-center-mapping-info/CHANGELOG.md
@@ -1,0 +1,9 @@
+# CHANGELOG
+
+## 1.0.0
+   -  initial push
+
+## 1.1.0
+   - Updated auto-permissionsets.py file to support customer managed policy in permission set.
+   - Updated the permission set example 5-example-sec-readonly.json
+   - Updated the instruction of customer managed policy in README.MD

--- a/identity-center-mapping-info/CHANGELOG.md
+++ b/identity-center-mapping-info/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ## 1.1.0
    - Updated auto-permissionsets.py file to support customer managed policy in permission set.
-      - Updated the permission set example 5-example-sec-readonly.json
+      - Updated the permission set example 5-example-sec-readonly.json.
    - Updated auto-permissionsets.py and identity-center-automation.template to support custom permission set session duration.
-      - Updated the permission set example 1-example-admin.json
-   - Updated the README.MD
+      - Default session duration is set to 1 hour.
+      - Updated the permission set example 1-example-admin.json.
+

--- a/identity-center-mapping-info/CHANGELOG.md
+++ b/identity-center-mapping-info/CHANGELOG.md
@@ -5,5 +5,7 @@
 
 ## 1.1.0
    - Updated auto-permissionsets.py file to support customer managed policy in permission set.
-   - Updated the permission set example 5-example-sec-readonly.json
-   - Updated the instruction of customer managed policy in README.MD
+      - Updated the permission set example 5-example-sec-readonly.json
+   - Updated auto-permissionsets.py and identity-center-automation.template to support custom permission set session duration.
+      - Updated the permission set example 1-example-admin.json
+   - Updated the README.MD

--- a/identity-center-mapping-info/permission-sets/1-example-admin.json
+++ b/identity-center-mapping-info/permission-sets/1-example-admin.json
@@ -1,6 +1,7 @@
 {
     "Name": "1-example-admin",
     "Description": "1-example-admin",
+    "Session_Duration": "PT12H", 
     "Tags": [
         {
             "Key": "identity-center-solution",

--- a/identity-center-mapping-info/permission-sets/4-example-operations.json
+++ b/identity-center-mapping-info/permission-sets/4-example-operations.json
@@ -17,10 +17,6 @@
             "Arn": "arn:aws:iam::aws:policy/job-function/SupportUser"
         },
         {
-            "Name": "AWSCodePipelineReadOnlyAccess",
-            "Arn": "arn:aws:iam::aws:policy/AWSCodePipelineReadOnlyAccess"
-        },
-        {
             "Name": "CloudWatchLogsReadOnlyAccess",
             "Arn": "arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess"
         }

--- a/identity-center-mapping-info/permission-sets/5-example-sec-readonly.json
+++ b/identity-center-mapping-info/permission-sets/5-example-sec-readonly.json
@@ -21,5 +21,15 @@
             "Arn": "arn:aws:iam::aws:policy/AWSSupportAccess"
         }
     ],
+    "CustomerPolicies": [
+        {
+            "Name": "customer-managed-policy-1",
+            "Path": "/IAM-path-example/"
+        },
+        {
+            "Name": "customer-managed-policy-2",
+            "Path": "/"
+        }
+    ], 
     "InlinePolicies": []
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-identitycenter-codepipeline-auto-assignment/issues/3
*Description of changes:*
Update the lambda function and template to add more features this solution.
   - Updated auto-permissionsets.py file to support customer managed policy in permission set.
      - Updated the permission set example 5-example-sec-readonly.json.
   - Updated auto-permissionsets.py and identity-center-automation.template to support custom permission set session duration.
      - Default session duration is set to 1 hour.
      - Updated the permission set example 1-example-admin.json.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
