### PR TITLE
Changing to adaptive boto4 retry with 100 max attempts for AWS API calls

### DIFF
--- a/src/automation-code/identity-center-auto-assign/auto-assignment.py
+++ b/src/automation-code/identity-center-auto-assign/auto-assignment.py
@@ -14,8 +14,8 @@ import watchtower
 
 AWS_CONFIG = Config(
     retries=dict(
-        max_attempts=8,
-        mode='standard'
+        max_attempts=100,
+        mode='adaptive'
     )
 )
 

--- a/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
+++ b/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
@@ -16,8 +16,8 @@ from botocore.exceptions import ClientError
 
 AWS_CONFIG = Config(
     retries=dict(
-        max_attempts=8,
-        mode='standard'
+        max_attempts=100,
+        mode='adaptive'
     )
 )
 

--- a/src/automation-code/permission-set-and-mapping-files-generator/auto-generate-permissionsets-mapping-files.py
+++ b/src/automation-code/permission-set-and-mapping-files-generator/auto-generate-permissionsets-mapping-files.py
@@ -47,8 +47,8 @@ boto_logger.addFilter(RetryFilter())
 
 AWS_CONFIG = Config(
     retries=dict(
-        max_attempts=5,
-        mode='standard'
+        max_attempts=100,
+        mode='adaptive'
     )
 )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changing to adaptive boto4 retry with 100 max attempts for AWS API calls

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
