### PR TITLE
Updating Parse and Scan buildspec to conduct cfn-nag scan on the new …

### DIFF
--- a/src/automation-code/identity-center-auto-assign/auto-assignment.py
+++ b/src/automation-code/identity-center-auto-assign/auto-assignment.py
@@ -346,7 +346,7 @@ def list_all_current_account_assignment(acct_list, current_aws_permission_sets):
 def drift_detect_update(all_assignments, global_file_contents,
                         target_file_contents, current_aws_permission_sets):
     """Use new mapping information to update IAM Identity Center assignments"""
-    logger.info('Starting assignment drift detection')
+    logger.info('Starting assignment drift detection. This may take some time...')
     check_list = all_assignments
     remove_list = []
     for each_assignment in check_list:

--- a/src/codebuild/buildspec-param.yml
+++ b/src/codebuild/buildspec-param.yml
@@ -31,6 +31,7 @@ phases:
       - cfn_nag_scan --input-path templates/delegate-admin/IC-Delegate-Admin.template
       - cfn_nag_scan --input-path templates/identity-center-s3-bucket.template
       - cfn_nag_scan --input-path templates/identity-center-automation.template
+      - cfn_nag_scan --input-path templates/management-account-org-events-forwarder.template
 
 artifacts:
   files:


### PR DESCRIPTION
*Description of changes:*
- Updating Parse and Scan buildspec to conduct cfn-nag scan on the new management-account-org-events-forwarder template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
