### PR TITLE
Bug Fix - Adding default session duration of 1 hour, when not specified in permission set file

### DIFF
--- a/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
+++ b/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
@@ -1178,7 +1178,7 @@ def sync_json_with_aws(local_files, aws_permission_sets):
             local_customer_policies = local_permission_set.get(
                 'CustomerPolicies', [])
             local_session_duration = local_permission_set.get(
-                'Session_Duration', [])
+                'Session_Duration', default_session_duration)
             local_boundary = local_permission_set.get(
                 'PermissionsBoundary', [])
 


### PR DESCRIPTION
*Issue #, if available:* #32

*Description of changes:*
Bug Fix - Adding default session duration of 1 hour, when not specified in permission set file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
