### PR TITLE
Bug Fix - pagination handling and retry logic for AWS IAM IdC API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,3 +242,21 @@ None. This is a non-breaking change focused on internal optimizations.
 
 - Compatibility
 Compatible with existing deployment structures and configuration files (pre-v3.0.0) and the new configuration file structure (v3.0.0 onwards).
+
+## 3.1.1
+
+### Bug Fixes & Improvements
+
+- Fixed global mapping target check to include 'TargetAccountid' field fallback
+- Updated Sid validation in inline policy statements:
+  - Added type checking for Sid values
+  - Restricted Sid pattern to alphanumeric characters only [a-z, A-Z, 0-9]
+- Added proper pagination for outdated permission sets check
+- Fixed log message formatting for managed policy operations
+- Removed deprecated start_automation function
+- Enhanced empty permission set component handling using .get() with default values
+
+### Notes
+
+- Non-breaking changes focused on validation and bug fixes
+- Compatible with existing deployment structures

--- a/src/automation-code/identity-center-auto-assign/auto-assignment.py
+++ b/src/automation-code/identity-center-auto-assign/auto-assignment.py
@@ -505,7 +505,7 @@ def generate_expected_assignments(global_mappings, target_mappings, current_aws_
 
     # Process global mappings
     for mapping in global_mappings:
-        if str(mapping.get('Target', '')).upper() != "GLOBAL":
+        if str(mapping.get('Target', mapping.get('TargetAccountid', ''))).upper() != "GLOBAL":
             continue
         group_id = get_valid_group_id(mapping['GlobalGroupName'])
         if not group_id:

--- a/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
+++ b/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
@@ -861,7 +861,7 @@ def add_managed_policy_to_perm_set(local_name, perm_set_arn, managed_policy_arn)
             f'Managed Policy {managed_policy_arn} added to {local_name} - {perm_set_arn}')
     except ic_admin.exceptions.ConflictException as error:
         logger.warning(
-            "%s.The same IAM Identity Center process may have been started in another invocation, or check for potential conflicts; skipping...", error)
+            "%s. The same IAM Identity Center process may have been started in another invocation, or check for potential conflicts; skipping...", error)
     except ClientError as error:
         error_message = f'Client error occurred: {error}'
         log_and_append_error(error_message)

--- a/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
+++ b/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
@@ -255,11 +255,10 @@ def process_permission_set(local_perm_set, aws_permission_sets):
         with ThreadPoolExecutor(max_workers=len(components)) as executor:
             futures = []
             for key, func in components:
-                if key in local_perm_set:
-                    futures.append(executor.submit(
-                        execute_with_retry, func, perm_set_name,
-                        local_perm_set.get(key, []), perm_set_arn
-                    ))
+                futures.append(executor.submit(
+                    execute_with_retry, func, perm_set_name,
+                    local_perm_set.get(key, []), perm_set_arn
+                ))
             futures.append(executor.submit(
                 execute_with_retry, sync_description, perm_set_name, perm_set_arn,
                 local_description, aws_description

--- a/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
+++ b/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
@@ -992,14 +992,14 @@ def sync_customer_policies(local_name, local_customer_policies, perm_set_arn):
 
     aws_policies = []
     paginator = ic_admin.get_paginator(
-        'list_managed_policies_in_permission_set')
+        'list_customer_managed_policy_references_in_permission_set')
 
     try:
         for page in paginator.paginate(
             InstanceArn=ic_instance_arn,
             PermissionSetArn=perm_set_arn
         ):
-            aws_policies.extend(page['AttachedManagedPolicies'])
+            aws_policies.extend(page['CustomerManagedPolicyReferences'])
     except Exception as e:
         logger.error(f"Error fetching managed policies for {local_name}: {e}")
         raise

--- a/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
+++ b/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
@@ -258,7 +258,7 @@ def process_permission_set(local_perm_set, aws_permission_sets):
                 if key in local_perm_set:
                     futures.append(executor.submit(
                         execute_with_retry, func, perm_set_name,
-                        local_perm_set[key], perm_set_arn
+                        local_perm_set.get(key, []), perm_set_arn
                     ))
             futures.append(executor.submit(
                 execute_with_retry, sync_description, perm_set_name, perm_set_arn,

--- a/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
+++ b/src/automation-code/identity-center-auto-permissionsets/auto-permissionsets.py
@@ -325,7 +325,10 @@ def is_provisioned_or_outdated(perm_set_name, perm_set_arn, account):
         provisioned = []
         paginator = ic_admin.get_paginator(
             'list_permission_sets_provisioned_to_account')
-        for page in paginator.paginate(InstanceArn=ic_instance_arn, AccountId=account):
+        for page in paginator.paginate(
+            InstanceArn=ic_instance_arn,
+            AccountId=account
+        ):
             provisioned.extend(page.get('PermissionSets', []))
 
         if provisioned:
@@ -333,11 +336,13 @@ def is_provisioned_or_outdated(perm_set_name, perm_set_arn, account):
                 return (perm_set_name, perm_set_arn, account, 'never_provisioned')
 
         # Check outdated
-        outdated = ic_admin.list_permission_sets_provisioned_to_account(
+        outdated = []
+        for page in paginator.paginate(
             InstanceArn=ic_instance_arn,
             AccountId=account,
             ProvisioningStatus='LATEST_PERMISSION_SET_NOT_PROVISIONED'
-        ).get('PermissionSets', [])
+        ):
+            outdated.extend(page.get('PermissionSets', []))
 
         if perm_set_arn in outdated:
             return (perm_set_name, perm_set_arn, account, 'outdated')
@@ -542,8 +547,11 @@ def deprovision_account(perm_set_arn, perm_set_name, account):
             return True, perm_set_name, perm_set_arn
         assignments = []
         paginator = ic_admin.get_paginator('list_account_assignments')
-        for page in paginator.paginate(InstanceArn=ic_instance_arn, AccountId=account, PermissionSetArn=perm_set_arn
-                                       )['AccountAssignments']:
+        for page in paginator.paginate(
+            InstanceArn=ic_instance_arn,
+            AccountId=account,
+            PermissionSetArn=perm_set_arn
+        ):
             assignments.extend(page.get('AccountAssignments', []))
 
         for assignment in assignments:
@@ -692,7 +700,9 @@ def get_all_permission_sets(delegated_admin=False):
         # List all permission set ARNs
         paginator = ic_admin.get_paginator('list_permission_sets')
         all_arns = []
-        for page in paginator.paginate(InstanceArn=ic_instance_arn):
+        for page in paginator.paginate(
+            InstanceArn=ic_instance_arn
+        ):
             all_arns.extend(page['PermissionSets'])
 
         # Parallel processing of permission sets
@@ -708,11 +718,14 @@ def get_all_permission_sets(delegated_admin=False):
                 name = ps['Name']
 
                 # Check Control Tower management
-                tags = execute_with_retry(
-                    ic_admin.list_tags_for_resource,
+                tags = []
+                paginator = ic_admin.get_paginator('list_tags_for_resource')
+                for page in execute_with_retry(
+                    paginator.paginate,
                     InstanceArn=ic_instance_arn,
                     ResourceArn=arn
-                )['Tags']
+                ):
+                    tags.extend(page['Tags'])
                 if any(t['Key'] == 'managedBy' and t['Value'] == 'ControlTower' for t in tags):
                     skipped.add((name, arn, "Control Tower"))
                     return None
@@ -722,7 +735,8 @@ def get_all_permission_sets(delegated_admin=False):
                     account_ids = []
                     paginator = ic_admin.get_paginator(
                         'list_accounts_for_provisioned_permission_set')
-                    for page in paginator.paginate(
+                    for page in execute_with_retry(
+                        paginator.paginate,
                         InstanceArn=ic_instance_arn,
                         PermissionSetArn=arn
                     ):
@@ -781,7 +795,8 @@ def get_provisioned_accounts(perm_set_arn):
     try:
         paginator = ic_admin.get_paginator(
             'list_accounts_for_provisioned_permission_set')
-        for page in paginator.paginate(
+        for page in execute_with_retry(
+            paginator.paginate,
             InstanceArn=ic_instance_arn,
             PermissionSetArn=perm_set_arn
         ):
@@ -843,7 +858,7 @@ def add_managed_policy_to_perm_set(local_name, perm_set_arn, managed_policy_arn)
             ManagedPolicyArn=managed_policy_arn
         )
         logger.info(
-            f'Managed Policy  {managed_policy_arn} to {local_name} - {perm_set_arn}')
+            f'Managed Policy {managed_policy_arn} added to {local_name} - {perm_set_arn}')
     except ic_admin.exceptions.ConflictException as error:
         logger.warning(
             "%s.The same IAM Identity Center process may have been started in another invocation, or check for potential conflicts; skipping...", error)
@@ -938,11 +953,13 @@ def sync_managed_policies(local_name, local_managed_policies, perm_set_arn):
     """Synchronize Managed Policies using set operations."""
     logger.info(f'Syncing AWS Managed Policies for {local_name}')
 
-    aws_policies = execute_with_retry(
-        ic_admin.list_managed_policies_in_permission_set,
+    aws_policies = []
+    paginator = ic_admin.get_paginator('list_managed_policies_in_permission_set')
+    for page in paginator.paginate(
         InstanceArn=ic_instance_arn,
         PermissionSetArn=perm_set_arn
-    )['AttachedManagedPolicies']
+    ):
+        aws_policies.extend(page['AttachedManagedPolicies'])
     aws_policy_map = {p['Name']: p['Arn'] for p in aws_policies}
     aws_names = set(aws_policy_map.keys())
 
@@ -973,11 +990,19 @@ def sync_customer_policies(local_name, local_customer_policies, perm_set_arn):
     """Sync customer-managed policies using set operations."""
     logger.info(f'Syncing Customer Policies for {local_name}')
 
-    aws_policies = execute_with_retry(
-        ic_admin.list_customer_managed_policy_references_in_permission_set,
-        InstanceArn=ic_instance_arn,
-        PermissionSetArn=perm_set_arn
-    )['CustomerManagedPolicyReferences']
+    aws_policies = []
+    paginator = ic_admin.get_paginator(
+        'list_managed_policies_in_permission_set')
+
+    try:
+        for page in paginator.paginate(
+            InstanceArn=ic_instance_arn,
+            PermissionSetArn=perm_set_arn
+        ):
+            aws_policies.extend(page['AttachedManagedPolicies'])
+    except Exception as e:
+        logger.error(f"Error fetching managed policies for {local_name}: {e}")
+        raise
     aws_policy_set = {(p['Name'], p['Path']) for p in aws_policies}
 
     local_policy_set = {(p['Name'], p['Path'])
@@ -1252,11 +1277,18 @@ def sync_tags(local_name, local_tags, perm_set_arn):
     logger.info(f'Syncing tags for {local_name}')
 
     # Fetch current tags
-    aws_tags = execute_with_retry(
-        ic_admin.list_tags_for_resource,
-        InstanceArn=ic_instance_arn,
-        ResourceArn=perm_set_arn
-    )['Tags']
+    aws_tags = []
+    paginator = ic_admin.get_paginator('list_tags_for_resource')
+
+    try:
+        for page in paginator.paginate(
+            InstanceArn=ic_instance_arn,
+            ResourceArn=perm_set_arn
+        ):
+            aws_tags.extend(page['Tags'])
+    except Exception as e:
+        logger.error(f"Error fetching tags for {local_name}: {e}")
+        raise
     aws_tag_set = {(t['Key'], t['Value']) for t in aws_tags}
     local_tag_set = {(t['Key'], t['Value']) for t in local_tags}
 
@@ -1294,37 +1326,6 @@ def is_account_active(account_id):
         logger.warning(
             f"Error checking account status for {account_id}: {error}")
         return False
-
-
-def start_automation():
-    logger.debug(f"Delegated: {delegated}")
-    delegated_admin = delegated == 'true'
-    try:
-        logger.info("The automation process is now started.")
-
-        logger.info("Starting the automation process...")
-        aws_permission_sets = get_all_permission_sets(delegated_admin)
-
-        if skipped_perm_set:
-            try:
-                sync_table_for_skipped_perm_sets(skipped_perm_set)
-            except Exception as error:
-                error_message = f'Failed to invoke sync_table_for_skipped_perm_sets: {error}'
-                log_and_append_error(error_message)
-        local_files = get_all_json_files(ic_bucket_name)
-
-        # Process sync
-        sync_json_with_aws(local_files, aws_permission_sets)
-
-        logger.info("Execution completed! \
-                    Check the auto permission set function logs for further execution details.")
-        logger.info(f'Codebuild logs contain combined logs for the build project.\
-                If you wish to view the logs for just the auto-permissionSet function, you can check out CloudWatch logs: "{permission_set_automation_log_group}/[buildId]-{build_id}"\
-                    https://{runtime_region}.console.aws.amazon.com/cloudwatch/home?region={runtime_region}#logsV2:log-groups/log-group/{permission_set_automation_log_group}/log-events/[buildId]-{build_id}')
-
-    except Exception as error:
-        error_message = f'Exception occurred: {error}'
-        log_and_append_error(error_message)
 
 
 # @profile(stdout=False, filename='profile_permission_sets.prof')

--- a/src/validation/syntax-validator.py
+++ b/src/validation/syntax-validator.py
@@ -133,8 +133,13 @@ def validate_inline_policy_statement(statement: dict) -> tuple[bool, str]:
 
     # Validate Sid if present
     if "Sid" in statement:
-        if not re.match(r'^[\w+=,.@-]+$', statement["Sid"]):
-            return False, "Sid must contain only alphanumeric characters and [+=,.@-]"
+        sid = statement["Sid"]
+        if not isinstance(sid, str):
+            return False, "Sid must be a string"
+        
+        sid_pattern = r'^[a-zA-Z0-9]+$'
+        if not re.match(sid_pattern, sid):
+            return False, "Sid must only contain alphanumeric characters [a-z, A-Z, 0-9]"
 
     return True, ""
 


### PR DESCRIPTION
*Issue #, if available:* 

1. Implementing proper pagination handling for multiple API calls including:
   - list_tags_for_resource
   - list_managed_policies_in_permission_set
   - list_customer_managed_policy_references_in_permission_set
   - list_accounts_for_provisioned_permission_set

2. Adding retry logic using execute_with_retry() for pagination operations to handle transient API failures

3. Fixing error handling and logging in various API calls

4. Removing unused start_automation() function