### PR TITLE
Support for Permission Set based roles in syntax validtator

### DIFF
--- a/src/validation/syntax-validator.py
+++ b/src/validation/syntax-validator.py
@@ -44,9 +44,9 @@ def is_valid_iam_role_arn(arn: str) -> bool:
 
     pattern = (
         r'^arn:aws:iam::\d{12}:role/'
-        r'(?:aws-service-role/[a-z0-9.-]+\.amazonaws\.com/)?'
+        r'(?:aws-service-role/[a-z0-9.-]+\.amazonaws\.com/|'
         r'aws-reserved/sso\.amazonaws\.com/[a-zA-Z0-9_+=,.@-]+/)?'
-        r'[a-zA-Z0-9+=,.@_-]{1,64}$'
+        r'[a-zA-Z0-9+=,.@_-]{1,2048}$'
     )
 
     return bool(re.match(pattern, arn))


### PR DESCRIPTION
*Issue #, if available:*
Syntax-validator does not support roles provisioned via permission sets.  e.g aws-reserved/sso
*Description of changes:*
Updates to src/validation/syntax-validator.py -> is_valid_iam_role_arn function to allow longer role names and support for 
roles created by Permission sets.    

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
